### PR TITLE
change frame_id and child_frame_id to for robot_localization

### DIFF
--- a/src/innok_heros_can_driver.cpp
+++ b/src/innok_heros_can_driver.cpp
@@ -152,8 +152,8 @@ void publishOdomMsg()
     
     nav_msgs::Odometry odom_msg;
     odom_msg.header.stamp = ros::Time::now();
-    odom_msg.header.frame_id = "/odom";
-    odom_msg.child_frame_id = "/base_link";
+    odom_msg.header.frame_id = "odom";
+    odom_msg.child_frame_id = "base_link";
     odom_msg.pose.pose.position.x = odom_pos_x;
     odom_msg.pose.pose.position.y = odom_pos_y;
     odom_msg.pose.pose.orientation = odom_quaternion;


### PR DESCRIPTION
The popular [robot_localization](http://docs.ros.org/kinetic/api/robot_localization/html/index.html) requires the odom frame to be named "odom" instead of "/odom" and child frame to be called "base_link" instead of "/base_link". Is there any reason you appended the slash in the original code?

Thanks